### PR TITLE
Remove .env from test project file

### DIFF
--- a/src/DotnetTests/DotnetTests.csproj
+++ b/src/DotnetTests/DotnetTests.csproj
@@ -27,10 +27,4 @@
     <ProjectReference Include="..\PersistenceService\PersistenceService.csproj" />
   </ItemGroup>
 
- <ItemGroup>
-    <Content Include=".env">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup> 
-
 </Project>


### PR DESCRIPTION
An exception will be thrown anyway if a .env file is not present and it should be. Doing this to make the CI build work.